### PR TITLE
Use a dramtically smaller Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM rust:1.50.0
+FROM rust:1.52.1-alpine3.13 as builder
 
-ENV PATH /app/bin:$PATH
+RUN apk add --no-cache musl-dev \
+    && rm -rf /var/cache/apk/*
+
 WORKDIR /build
 COPY . /build
 RUN cargo build --release
 
+FROM alpine:3.13
+
+ENV PATH /app/bin:$PATH
 RUN mkdir -p /app/bin
 RUN mkdir -p /app/conf
-RUN cp /build/target/release/pinyin_tone_marks /app/bin
-RUN cp /build/conf/log4rs.yaml /app/conf
-WORKDIR /
-RUN rm -rf /build
+COPY --from=builder /build/target/release/pinyin_tone_marks /app/bin
+COPY --from=builder /build/conf/log4rs.yaml /app/conf
 
 ENTRYPOINT ["pinyin_tone_marks"]


### PR DESCRIPTION
By using Alpine and using a builder image we were able to
drastically reduce the size of our image!